### PR TITLE
Swap targets

### DIFF
--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -11,11 +11,10 @@ combine_nwis_data <- function(site_paths){
   return(data_out)
 }
 
-nwis_site_info <- function(fileout, site_data){
+nwis_site_info <- function(site_data){
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
-  write_csv(site_info, fileout)
-  return(fileout)
+  return(site_info)
 }
 
 

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -5,15 +5,15 @@ process_data <- function(nwis_data){
   return(nwis_data_clean)
 }
 
-annotate_data <- function(site_data_clean, site_filename){
-  site_info <- read_csv(site_filename)
+annotate_data <- function(site_data_clean, site_info, out_filename){
   annotated_data <- left_join(site_data_clean, site_info, by = "site_no") %>% 
     select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va)
   
   # make station name a factor
   styled_data <- style_data(annotated_data)
   
-  return(styled_data)
+  write_csv(styled_data, out_filename)
+  return(out_filename)
 }
 
 

--- a/3_visualize/src/plot_timeseries.R
+++ b/3_visualize/src/plot_timeseries.R
@@ -1,8 +1,7 @@
-plot_nwis_timeseries <- function(fileout, site_data_styled, width = 12, height = 7, units = 'in'){
-  
-  ggplot(data = site_data_styled, aes(x = dateTime, y = water_temperature, color = station_name)) +
+plot_nwis_timeseries <- function(site_data_annotated_csv, width = 12, height = 7, units = 'in'){
+  site_data_styled = read_csv(site_data_annotated_csv)
+  gg_obj = ggplot(data = site_data_styled, aes(x = dateTime, y = water_temperature, color = station_name)) +
     geom_line() + theme_bw()
-  ggsave(fileout, width = width, height = height, units = units)
   
-  return(fileout)
+  return(gg_obj)
 }

--- a/_targets.R
+++ b/_targets.R
@@ -66,9 +66,8 @@ p1_targets_list <- list(
     combine_nwis_data(c(station1_csv, station2_csv, station3_csv, station4_csv, station5_csv))
   ),
   tar_target(
-    site_info_csv,
-    nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),
-    format = "file"
+    site_info,
+    nwis_site_info(site_data)
   )
 )
 
@@ -78,17 +77,17 @@ p2_targets_list <- list(
     process_data(site_data)
   ),
   tar_target(
-    site_data_annotated,
-    annotate_data(site_data_clean, site_filename = site_info_csv)
+    site_data_annotated_csv,
+    annotate_data(site_data_clean, site_info = site_info, out_filename = '2_process/out/site_data_annotated.csv'),
+    format = "file"
   )
 )
 
 p3_targets_list <- list(
   tar_target(
-    figure_1_png,
-    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_annotated,
-                         width = p_width, height = p_height, units = p_units),
-    format = "file"
+    figure_1,
+    plot_nwis_timeseries(site_data_annotated_csv = site_data_annotated_csv,
+                         width = p_width, height = p_height, units = p_units)
   )
 )
 


### PR DESCRIPTION
Addresses issue #8.

The site info are now returned as an object. These are later appended to the processed dataframe, so it seems better as an object than separate file.

Annotated and styled data are now saved to a file. This seemed useful as a final processed data product.

I changed the figure to return a ggplot object instead of save a file. Is there a way to add the ggsave arguments to the returned object? Or should that be a separate function?